### PR TITLE
Add markdown links to june meetup

### DIFF
--- a/_posts/2025-06-19-meeting-016.md
+++ b/_posts/2025-06-19-meeting-016.md
@@ -32,51 +32,51 @@ Questions are encouraged, including basic ones!
 ### News
 
 - Steak and Shake accepts Bitcoin
-   - https://x.com/SteaknShake/status/1923426316478558571
+   - https://x.com/SteaknShake/status/1923426316478558571>
 - Block to roll out accepting bitcoin payments on square terminals
-   - https://squareup.com/us/en/press/block-to-roll-out-bitcoin-payments-on-square
-   - https://www.forbes.com/sites/digital-assets/2025/05/31/bitcoin-breaks-a-guinness-world-record-with-4000-pos-payments/
+   - https://squareup.com/us/en/press/block-to-roll-out-bitcoin-payments-on-square>
+   - https://www.forbes.com/sites/digital-assets/2025/05/31/bitcoin-breaks-a-guinness-world-record-with-4000-pos-payments/>
 
 ### Bitcoin
 
 - Relay policy merged into core
-   - https://bitcoincore.org/en/2025/06/06/relay-statement/
-   - https://knotsgoup.vercel.app/
+   - <https://bitcoincore.org/en/2025/06/06/relay-statement/>
+   - <https://knotsgoup.vercel.app/>
 - Bitcoin devs sign letter advocating for CTV+CSFS
-   - https://ctv-csfs.com
+   - <https://ctv-csfs.com>
 - BDK-wallet 2.0.0
-   - https://github.com/bitcoindevkit/bdk_wallet/releases/tag/wallet-2.0.0
+   - <https://github.com/bitcoindevkit/bdk_wallet/releases/tag/wallet-2.0.0>
 - NFC support for reading NFC in Phoenix
-   - https://github.com/ACINQ/phoenix/releases/tag/android-v2.6.1
-   - https://github.com/btcpayserver/BTCPayServer.Lightning/pull/169
+   - <https://github.com/ACINQ/phoenix/releases/tag/android-v2.6.1>
+   - <https://github.com/btcpayserver/BTCPayServer.Lightning/pull/169>
 
 
 ### Lightning
 
 - Stable channels
-   - https://stablechannels.com/
+   - <https://stablechannels.com/
 - Yield bros rejoice
-   - https://x.com/ambosstech/status/1928194644699140509
-   - https://x.com/moneyball/status/1930259490076553719
-   - https://x.com/bitrefill/status/1930217463779676334
+   - <https://x.com/ambosstech/status/1928194644699140509>
+   - <https://x.com/moneyball/status/1930259490076553719>
+   - <https://x.com/bitrefill/status/1930217463779676334>
 
 ### Policy
 
 - Clarity Act
-   - https://www.congress.gov/bill/119th-congress/house-bill/3633/text/ih
-   - https://saveourwallets.org/
+   - <https://www.congress.gov/bill/119th-congress/house-bill/3633/text/ih>
+   - <https://saveourwallets.org/>
 
 ### Research
 
 - Utxo dust clearing
-   - https://delvingbitcoin.org/t/dust-expiry-clean-the-utxo-set-from-spam/1707
-   - https://research.mempool.space/utxo-set-report/
+   - <https://delvingbitcoin.org/t/dust-expiry-clean-the-utxo-set-from-spam/1707>
+   - <https://research.mempool.space/utxo-set-report/>
 - SCEWL - Sharing Coins Effectively with Ladders
-   - https://supertestnet.github.io/scewl/
+   - <https://supertestnet.github.io/scewl/>
 - LOCK protocol
-   - https://github.com/bramkanstein/lock-protocol
+   - <https://github.com/bramkanstein/lock-protocol
 - New Opcodes
-   - https://github.com/rustyrussell/bips/blob/207e292ac989c8b628feed31f22020764b6b71e9/bip-unknown-covenant-support-opcodes.mediawiki
+   - <https://github.com/rustyrussell/bips/blob/207e292ac989c8b628feed31f22020764b6b71e9/bip-unknown-covenant-support-opcodes.mediawiki>
 
 ## Submit suggestions for next meeting!
 


### PR DESCRIPTION
Fix a typo to make the links for meetup 16 clickable.