### PR TITLE
Add topics issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/topics.yml
+++ b/.github/ISSUE_TEMPLATE/topics.yml
@@ -1,0 +1,9 @@
+name: DC BitDevs Topic Suggestion
+description: Topics list for the next Socratic Seminar
+labels: [topics]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please list topics in this thread
+


### PR DESCRIPTION
Adds a new topics issue template for the next seminar

Possibly we can add a way to track what the next issue is to be auto-populated